### PR TITLE
feat: handle array headers in node collector

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "tsup src/index.ts --dts --format esm,cjs,iife --global-name NativeliteFP --out-dir dist --minify --sourcemap --metafile --clean",
     "dev": "tsup src/index.ts --watch --format esm,cjs --dts",
     "check": "tsc --noEmit -p tsconfig.json",
+    "test": "npx tsx test/signals.node.test.ts",
     "size": "npm run build && node scripts/size.mjs",
     "size:limit": "npm run build && size-limit",
     "analyze": "npm run build && size-limit --why"

--- a/src/signals.node.ts
+++ b/src/signals.node.ts
@@ -1,13 +1,17 @@
 import type { NodeCollectOptions, Signals } from "./types.js";
 import { VERSION } from "./utils.js";
 
-function hget(h: Record<string, any> | undefined, key: string): string | undefined {
-  if (!h) return undefined; const v = h[key] ?? h[key.toLowerCase()];
-  return Array.isArray(v) ? v[0] : (v != null ? String(v) : undefined);
+function hget(
+  h: Record<string, string | string[] | undefined> | undefined,
+  key: string
+): string | undefined {
+  if (!h) return undefined;
+  const v = h[key] ?? h[key.toLowerCase()];
+  return Array.isArray(v) ? v[0] : v != null ? String(v) : undefined;
 }
 
 export async function collectSignalsNode(opts: NodeCollectOptions = {}): Promise<Signals> {
-  const headers = (opts.headers || {}) as Record<string, any>;
+  const headers = opts.headers || {};
   const data: Signals = { _version: VERSION };
 
   data.ua = hget(headers, 'user-agent');

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface BaseCollectOptions {
 export interface BrowserCollectOptions extends BaseCollectOptions {}
 
 export interface NodeCollectOptions extends BaseCollectOptions {
-  headers?: Record<string, string | string | undefined>;
+  headers?: Record<string, string | string[] | undefined>;
   ip?: string | null;
 }
 

--- a/test/signals.node.test.ts
+++ b/test/signals.node.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { collectSignalsNode } from '../src/signals.node.js';
+
+async function run() {
+  const headersString = {
+    'user-agent': 'test-agent',
+    'accept-language': 'en-US,fr'
+  };
+  const headersArray = {
+    'user-agent': ['test-agent'],
+    'accept-language': ['en-US,fr']
+  };
+
+  const res1 = await collectSignalsNode({ headers: headersString });
+  assert.equal(res1.ua, 'test-agent');
+  assert.deepEqual(res1.languages, ['en-US', 'fr']);
+
+  const res2 = await collectSignalsNode({ headers: headersArray });
+  assert.equal(res2.ua, 'test-agent');
+  assert.deepEqual(res2.languages, ['en-US', 'fr']);
+
+  console.log('ok');
+}
+
+run();


### PR DESCRIPTION
## Summary
- allow NodeCollectOptions headers to include string arrays
- handle array header values in `collectSignalsNode`
- add test covering string and array headers

## Testing
- `npm test`
- `npm run check` *(fails: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource')*