### PR TITLE
Add Node crypto fallback to hash function

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,8 +1,15 @@
 import { b64url } from "./utils.js";
 export async function hashBytes(bytes: Uint8Array): Promise<string> {
   if (globalThis.crypto?.subtle) {
-    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    const digest = await crypto.subtle.digest("SHA-256", bytes.buffer as ArrayBuffer);
     return b64url(digest);
+  }
+  if ((globalThis.crypto as any)?.createHash) {
+    const hash = (globalThis.crypto as any).createHash("sha256");
+    hash.update(bytes as any);
+    const digest: Uint8Array = hash.digest();
+    const ab = digest.buffer.slice(digest.byteOffset, digest.byteOffset + digest.byteLength) as ArrayBuffer;
+    return b64url(ab);
   }
   let h = 0xcbf29ce484222325n; const p = 0x100000001b3n;
   for (const x of bytes) { h ^= BigInt(x); h = (h * p) & 0xffffffffffffffffn; }

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hashString } from '../dist/hash.js';
+
+test('subtle and node crypto produce same hash', async () => {
+  const input = 'hello world';
+  const originalCrypto = globalThis.crypto;
+  const subtleHash = await hashString(input);
+  const { createHash } = await import('node:crypto');
+  Object.defineProperty(globalThis, 'crypto', { value: { createHash }, configurable: true });
+  const nodeHash = await hashString(input);
+  Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
+  assert.equal(nodeHash, subtleHash);
+});


### PR DESCRIPTION
## Summary
- support hashing with `crypto.createHash` when `crypto.subtle` is unavailable
- verify Node and Web Crypto hashes match

## Testing
- `npm run check`
- `node --test test/hash.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b28b7a89a08320aa87a9c02685e301