### PR TITLE
Handle async canvas hash failures

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,7 +1,8 @@
 import { b64url } from "./utils.js";
 export async function hashBytes(bytes: Uint8Array): Promise<string> {
   if (globalThis.crypto?.subtle) {
-    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+    const digest = await crypto.subtle.digest("SHA-256", buf);
     return b64url(digest);
   }
   let h = 0xcbf29ce484222325n; const p = 0x100000001b3n;

--- a/src/signals.browser.ts
+++ b/src/signals.browser.ts
@@ -1,6 +1,6 @@
 import { hashString } from "./hash.js";
 import type { BrowserCollectOptions, Signals } from "./types.js";
-import { VERSION, tryGet } from "./utils.js";
+import { VERSION, tryGet, tryGetAsync } from "./utils.js";
 
 export async function collectSignalsBrowser(opts: BrowserCollectOptions = {}): Promise<Signals> {
   const d = typeof document !== "undefined" ? document : (undefined as any);
@@ -52,13 +52,12 @@ export async function collectSignalsBrowser(opts: BrowserCollectOptions = {}): P
       for (const f of fonts) { ctx.font = `16px ${f}`; const m = ctx.measureText("nativelite-fp"); samples[f] = Math.round((m.width ?? 0) * 1000); }
       return samples;
     });
-    data.canvasHash = tryGet(async () => {
+    data.canvasHash = await tryGetAsync(async () => {
       const c = d.createElement("canvas"); c.width = 240; c.height = 40;
       const ctx = c.getContext("2d"); if (!ctx) return undefined;
       ctx.textBaseline = "top"; ctx.font = "14px 'Arial'"; ctx.fillText("@nativelite/fp", 2, 2);
       return await hashString(c.toDataURL());
     });
-    if (data.canvasHash instanceof Promise) data.canvasHash = await data.canvasHash;
   }
 
   if (stableOnly) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,4 +13,11 @@ export function toJSONStable(val: unknown): string {
   return JSON.stringify(val);
 }
 export function tryGet<T>(fn: () => T): T | undefined { try { return fn(); } catch { return undefined; } }
+export async function tryGetAsync<T>(fn: () => Promise<T> | T): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch {
+    return undefined;
+  }
+}
 export function eq(a: unknown, b: unknown): boolean { return toJSONStable(a) === toJSONStable(b); }

--- a/tests/canvasHash.test.ts
+++ b/tests/canvasHash.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+
+// stub minimal DOM environment
+const fakeCtx = {
+  textBaseline: '',
+  font: '',
+  fillText: () => {},
+  measureText: () => ({ width: 0 })
+};
+const fakeCanvas = {
+  width: 0,
+  height: 0,
+  getContext: () => fakeCtx,
+  toDataURL: () => 'data:'
+};
+(globalThis as any).document = { createElement: () => fakeCanvas };
+(globalThis as any).navigator = {};
+(globalThis as any).window = { devicePixelRatio: 1, screen: { colorDepth: 24, width: 0, height: 0 } };
+(globalThis as any).crypto ??= {};
+(globalThis as any).crypto.subtle ??= {};
+(globalThis as any).crypto.subtle.digest = async () => { throw new Error('fail'); };
+
+const { collectSignalsBrowser } = await import('../src/signals.browser.ts');
+const signals = await collectSignalsBrowser({ heavy: true });
+assert.equal(signals.canvasHash, undefined);
+console.log('canvasHash test passed');


### PR DESCRIPTION
## Summary
- add `tryGetAsync` helper to await callbacks and swallow rejections
- use async helper for `canvasHash` to avoid unhandled promise rejections
- adjust hashing to digest array buffer slice for type safety
- add test proving async hash failures return undefined

## Testing
- `tsc --noEmit -p tsconfig.json`
- `TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm tests/canvasHash.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b28b78649883208f56cbb2d46a1022