### PR TITLE
feat: ensure stable array serialization

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,13 +4,21 @@ export function b64url(ab: ArrayBuffer): string {
   return btoa(b).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 export function toJSONStable(val: unknown): string {
-  if (val && typeof val === 'object' && !Array.isArray(val)) {
+  if (Array.isArray(val)) {
+    const arr = val as unknown[];
+    const json = arr.map((v) => {
+      const s = toJSONStable(v);
+      return s === undefined ? 'null' : s;
+    });
+    return `[${json.join(',')}]`;
+  }
+  if (val && typeof val === 'object') {
     const obj = val as Record<string, unknown>;
     const sorted: Record<string, unknown> = {};
     for (const k of Object.keys(obj).sort()) sorted[k] = toJSONStable(obj[k]);
     return JSON.stringify(sorted);
   }
-  return JSON.stringify(val);
+  return JSON.stringify(val) as string;
 }
 export function tryGet<T>(fn: () => T): T | undefined { try { return fn(); } catch { return undefined; } }
 export function eq(a: unknown, b: unknown): boolean { return toJSONStable(a) === toJSONStable(b); }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toJSONStable } from '../src/utils.ts';
+
+test('toJSONStable handles arrays with objects in any key order', () => {
+  const a = [{ a: 1, b: 2 }, { c: 3, d: 4 }];
+  const b = [{ b: 2, a: 1 }, { d: 4, c: 3 }];
+  assert.equal(toJSONStable(a), toJSONStable(b));
+});


### PR DESCRIPTION
## Summary
- recursively serialize array elements for stable JSON output
- test serialization when array objects have shuffled keys

## Testing
- `npm run check` *(fails: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource')*
- `tsc src/utils.ts --module ES2020 --moduleResolution node --target ES2020 --lib ES2020,DOM --outDir test-dist`
- `node -e "import('./test-dist/utils.js').then(m=>{const a=[{a:1,b:2},{c:3,d:4}];const b=[{b:2,a:1},{d:4,c:3}];if(m.toJSONStable(a)===m.toJSONStable(b)) console.log('stable'); else console.log('not stable');})"`