### PR TITLE
feat: use dynamic crypto fallback

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -5,12 +5,15 @@ export async function hashBytes(bytes: Uint8Array): Promise<string> {
     const digest = await crypto.subtle.digest("SHA-256", buf);
     return b64url(digest);
   }
-  if ((globalThis.crypto as any)?.createHash) {
-    const hash = (globalThis.crypto as any).createHash("sha256");
+  try {
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256");
     hash.update(bytes as any);
     const digest: Uint8Array = hash.digest();
     const ab = digest.buffer.slice(digest.byteOffset, digest.byteOffset + digest.byteLength) as ArrayBuffer;
     return b64url(ab);
+  } catch {
+    // no crypto module available, fall through to a non-cryptographic hash
   }
   let h = 0xcbf29ce484222325n; const p = 0x100000001b3n;
   for (const x of bytes) { h ^= BigInt(x); h = (h * p) & 0xffffffffffffffffn; }
@@ -18,4 +21,6 @@ export async function hashBytes(bytes: Uint8Array): Promise<string> {
   for (let i = 0; i < 32; i++) { h ^= BigInt(i) * 0x9e3779b97f4a7c15n; out[i] = Number(h & 0xffn); h >>= 1n; }
   return b64url(out.buffer);
 }
-export async function hashString(s: string): Promise<string> { return hashBytes(new TextEncoder().encode(s)); }
+export async function hashString(s: string): Promise<string> {
+  return hashBytes(new TextEncoder().encode(s));
+}

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -1,14 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { hashString } from '../dist/hash.js';
+import { hashString } from '../src/hash.ts';
 
 test('subtle and node crypto produce same hash', async () => {
   const input = 'hello world';
-  const originalCrypto = globalThis.crypto;
   const subtleHash = await hashString(input);
-  const { createHash } = await import('node:crypto');
-  Object.defineProperty(globalThis, 'crypto', { value: { createHash }, configurable: true });
-  const nodeHash = await hashString(input);
-  Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
-  assert.equal(nodeHash, subtleHash);
+  const originalCrypto = globalThis.crypto;
+  try {
+    Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true });
+    const nodeHash = await hashString(input);
+    assert.equal(nodeHash, subtleHash);
+  } finally {
+    Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
+  }
 });


### PR DESCRIPTION
## Summary
- load `node:crypto` on demand when Web Crypto is unavailable
- ensure hashing works even without `globalThis.crypto`
- test fallback hashing via simulated missing `crypto`

## Testing
- `npx -y tsx test/hash.test.js`
- `npx -y tsx test/signals.node.test.ts`