### PR TITLE
Refactor toJSONStable to preserve nested structures

### DIFF
--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -7,3 +7,13 @@ test('toJSONStable handles arrays with objects in any key order', () => {
   const b = [{ b: 2, a: 1 }, { d: 4, c: 3 }];
   assert.equal(toJSONStable(a), toJSONStable(b));
 });
+
+test('toJSONStable preserves nested object and array structure', () => {
+  const input = { z: [{ b: 2, a: 1 }, { d: 4, c: 3 }], y: { b: 2, a: 1 } };
+  const parsed = JSON.parse(toJSONStable(input));
+  assert.deepEqual(parsed, { y: { a: 1, b: 2 }, z: [{ a: 1, b: 2 }, { c: 3, d: 4 }] });
+});
+
+test('toJSONStable returns "null" for undefined', () => {
+  assert.equal(toJSONStable(undefined), 'null');
+});


### PR DESCRIPTION
## Summary
- Refactor `toJSONStable` to build intermediate values before a single `JSON.stringify`, ensuring nested objects remain objects and returning "null" for undefined inputs.
- Add tests covering nested objects/arrays and `undefined` serialization.

## Testing
- `npx -y tsx test/utils.test.ts`
- `npx -y tsx test/signals.node.test.ts`
- `node test/hash.test.js` *(fails: Cannot find module '/workspace/fp-js/dist/hash.js')*
- `npm run build` *(fails: tsup: not found)*
- `npm install` *(fails: 404 Not Found - GET https://registry.npmjs.org/@size-limit%2fwhy)*